### PR TITLE
java.lang.Runtime.exec overwrites environment.

### DIFF
--- a/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
+++ b/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
@@ -181,12 +181,13 @@ package com.openstudy { package sbt {
       streams.log.info("Compiling SASS files...")
 
       val runtime = java.lang.Runtime.getRuntime
-      val processEnvironment = System.getenv().map { case (key, value) => key + "=" + value } ++
-                               Some("asset_domain=" + bucket)
+      val environment = (System.getenv() + ("asset_domain" -> bucket)) map {
+        case (key, value) => key + "=" + value
+      }
       val process =
         runtime.exec(
           ("compass" :: "compile" :: "-e" :: "production" :: "--force" :: Nil).toArray,
-          processEnvironment.toArray)
+          environment.toArray)
       val result = process.waitFor
 
       if (result != 0) {


### PR DESCRIPTION
Around line 184 (in my branch, may vary in master for now) in doSassCompile we have the following code:

``` scala
val process =
  runtime.exec(
    ("compass" :: "compile" :: "-e" :: "production" :: "--force" :: Nil).toArray,
    ("asset_domain=" + bucket :: Nil).toArray)
```

This is a grand way to set the asset domain for compass, but it wreaks havoc if you're running this code on a system with RVM installed because, according to the [javadoc](http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html#exec%28java.lang.String[], java.lang.String[], java.io.File%29), it overwrites the environment that RVM set. The net result is that when compass runs it fails with a path error.

```
matt@FarmStudy:~/Sites/anchor-tab-scala(master)$ sbt resources:compile-sass
...
[warn]    org.scala-lang: 2.9.2, 2.9.1
[info] Compiling SASS files...
[error] env: ruby_noexec_wrapper: No such file or directory
java.lang.RuntimeException: SASS compilation failed with code 127.
```

I confirmed this was the issue by changing the second parameter in exec to `null`, and compass started working again (presumably because it had the correct environment).

It looks like `System` has a getenv call. One possible fix for this is:

``` scala
val environment = System.getenv().map { case (key, value) => key + "=" + value }
                  ++ ("asset_domain=" + bucket)
val process =
  runtime.exec(
    ("compass" :: "compile" :: "-e" :: "production" :: "--force" :: Nil).toArray,
    environment
```

Interested in hearing any thoughts along those lines. Might try implementing it myself.
