### PR TITLE
Gzip Me Up: Add gzipping flag to publish gzipped resources to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ specified S3 bucket with the specified bundles.
 Once again, there is a combination command,
 `resources:deploy-resources`, that runs both the deploy commands.
 
+## Gzipping
+
+By default, resources are stored in S3 in their original forms; however, you
+can request that they be gzipped and stored in S3 with a gzipped content
+encoding, so that they are served to the browser gzipped and the browser
+decompresses them automatically. To do this, simply enable the flag
+`gzipResources`:
+
+    gzipResources := true
+
 ## Checksums as part of the filename
 
 As noted by @[eltimn](https://github.com/eltimn) and

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-resource-management"
 
 organization := "com.openstudy"
 
-version := "0.5-SNAPSHOT"
+version := "0.5.0-SNAPSHOT"
 
 pomExtra :=
 <url>http://github.com/Shadowfiend/sbt-resource-management</url>

--- a/src/main/scala/com/openstudy/sbt/CssDeployment.scala
+++ b/src/main/scala/com/openstudy/sbt/CssDeployment.scala
@@ -11,7 +11,7 @@ trait CssDeployment extends Deployment {
 
   def doCssDeploy(
       streams: TaskStreams,
-      checksumInFilename: Boolean,
+      checksumInFilename: Boolean, gzipFiles: Boolean,
       bundleChecksums: Map[String,String],
       styleBundleVersions: File, compressedTarget: File,
       access: Option[String], secret: Option[String], defaultBucket: Option[String]) = {
@@ -21,7 +21,7 @@ trait CssDeployment extends Deployment {
       withBucketMapping(bundles, defaultBucket, customBucketMap) { (bucketName, files) =>
         doDeploy(
           streams,
-          checksumInFilename,
+          checksumInFilename, gzipFiles,
           bundleChecksums,
           styleBundleVersions, compressedTarget,
           files, "text/css",

--- a/src/main/scala/com/openstudy/sbt/Deployment.scala
+++ b/src/main/scala/com/openstudy/sbt/Deployment.scala
@@ -11,7 +11,14 @@ trait Deployment {
 
   def customBucketMap: scala.collection.mutable.HashMap[String, List[String]]
 
-  def doDeploy(streams:TaskStreams, checksumInFilename:Boolean, bundleChecksums:Map[String,String], bundleVersions:File, baseCompressedTarget:File, files:Seq[File], mimeType:String, bucket:String, access:Option[String], secret:Option[String]) = {
+  def doDeploy(
+      streams: TaskStreams,
+      checksumInFilename: Boolean, gzipFiles: Boolean,
+      bundleChecksums: Map[String,String],
+      bundleVersions: File, baseCompressedTarget: File,
+      files: Seq[File],
+      mimeType: String,
+      bucket: String, access: Option[String], secret: Option[String]) = {
     try {
       val handler = new S3Handler(bucket, access, secret)
 
@@ -30,7 +37,7 @@ trait Deployment {
 
         try {
           val contents = IO.readBytes(file)
-          handler.saveFile(mimeType, relativePath, contents)
+          handler.saveFile(mimeType, relativePath, contents, gzipped = gzipFiles)
 
           IO.append(bundleVersions, bundle + "=" + checksum + "\n")
         } catch {

--- a/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
+++ b/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
@@ -21,7 +21,7 @@ package com.openstudy { package sbt {
     val awsSecretKey = SettingKey[Option[String]]("aws-secret-key")
     val awsS3Bucket = SettingKey[Option[String]]("aws-s3-bucket")
     val checksumInFilename = SettingKey[Boolean]("checksum-in-filename")
-    val gzipFiles = SettingKey[Boolean]("gzipFiles")
+    val gzipResources = SettingKey[Boolean]("gzipResources")
 
     val targetJavaScriptDirectory = SettingKey[File]("target-java-script-directory")
     val bundleDirectory = SettingKey[File]("bundle-directory")
@@ -65,7 +65,7 @@ package com.openstudy { package sbt {
       awsSecretKey := None,
       awsS3Bucket := None,
       forceSassCompile := false,
-      gzipFiles := false,
+      gzipResources := false,
 
       bundleDirectory in ResourceCompile <<= (resourceDirectory in Compile)(_ / "bundles"),
       scriptBundle in ResourceCompile <<= (bundleDirectory in ResourceCompile)(_ / "javascript.bundle"),
@@ -89,8 +89,8 @@ package com.openstudy { package sbt {
       compileLess in ResourceCompile <<= (streams, baseDirectory, compiledLessDirectory in ResourceCompile, lessSources in ResourceCompile) map doLessCompile _,
       compressScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, copyScripts in ResourceCompile, targetJavaScriptDirectory in ResourceCompile, compressedTarget in ResourceCompile, scriptBundle in ResourceCompile) map doScriptCompress _,
       compressCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, compileSass in ResourceCompile, styleDirectories in ResourceCompile, compressedTarget in ResourceCompile, styleBundle in ResourceCompile) map doCssCompress _,
-      deployScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipFiles, compressScripts in ResourceCompile, scriptBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doScriptDeploy _,
-      deployCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipFiles, compressCss in ResourceCompile, styleBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doCssDeploy _,
+      deployScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipResources, compressScripts in ResourceCompile, scriptBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doScriptDeploy _,
+      deployCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipResources, compressCss in ResourceCompile, styleBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doCssDeploy _,
 
       compressResources in ResourceCompile <<= (compressScripts in ResourceCompile, compressCss in ResourceCompile) map { (thing, other) => },
       deployResources in ResourceCompile <<= (deployScripts in ResourceCompile, deployCss in ResourceCompile) map { (_, _) => },

--- a/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
+++ b/src/main/scala/com/openstudy/sbt/ResourceManagementPlugin.scala
@@ -21,6 +21,7 @@ package com.openstudy { package sbt {
     val awsSecretKey = SettingKey[Option[String]]("aws-secret-key")
     val awsS3Bucket = SettingKey[Option[String]]("aws-s3-bucket")
     val checksumInFilename = SettingKey[Boolean]("checksum-in-filename")
+    val gzipFiles = SettingKey[Boolean]("gzipFiles")
 
     val targetJavaScriptDirectory = SettingKey[File]("target-java-script-directory")
     val bundleDirectory = SettingKey[File]("bundle-directory")
@@ -64,6 +65,7 @@ package com.openstudy { package sbt {
       awsSecretKey := None,
       awsS3Bucket := None,
       forceSassCompile := false,
+      gzipFiles := false,
 
       bundleDirectory in ResourceCompile <<= (resourceDirectory in Compile)(_ / "bundles"),
       scriptBundle in ResourceCompile <<= (bundleDirectory in ResourceCompile)(_ / "javascript.bundle"),
@@ -87,8 +89,8 @@ package com.openstudy { package sbt {
       compileLess in ResourceCompile <<= (streams, baseDirectory, compiledLessDirectory in ResourceCompile, lessSources in ResourceCompile) map doLessCompile _,
       compressScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, copyScripts in ResourceCompile, targetJavaScriptDirectory in ResourceCompile, compressedTarget in ResourceCompile, scriptBundle in ResourceCompile) map doScriptCompress _,
       compressCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, compileSass in ResourceCompile, styleDirectories in ResourceCompile, compressedTarget in ResourceCompile, styleBundle in ResourceCompile) map doCssCompress _,
-      deployScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, compressScripts in ResourceCompile, scriptBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doScriptDeploy _,
-      deployCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, compressCss in ResourceCompile, styleBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doCssDeploy _,
+      deployScripts in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipFiles, compressScripts in ResourceCompile, scriptBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doScriptDeploy _,
+      deployCss in ResourceCompile <<= (streams, checksumInFilename in ResourceCompile, gzipFiles, compressCss in ResourceCompile, styleBundleVersions in ResourceCompile, compressedTarget in ResourceCompile, awsAccessKey, awsSecretKey, awsS3Bucket) map doCssDeploy _,
 
       compressResources in ResourceCompile <<= (compressScripts in ResourceCompile, compressCss in ResourceCompile) map { (thing, other) => },
       deployResources in ResourceCompile <<= (deployScripts in ResourceCompile, deployCss in ResourceCompile) map { (_, _) => },

--- a/src/main/scala/com/openstudy/sbt/S3Helpers.scala
+++ b/src/main/scala/com/openstudy/sbt/S3Helpers.scala
@@ -1,7 +1,8 @@
 package com.openstudy
 package sbt
 
-import java.io.ByteArrayInputStream
+import java.io._
+import java.util.zip.GZIPOutputStream
 
 import com.amazonaws.auth._
 import com.amazonaws.services.s3._
@@ -38,11 +39,27 @@ class S3Handler(bucket: String, val accessKey: Option[String], val secretKey: Op
 
   // Returns the MD5 checksum of the file.
   def saveFile(mime: String, fileName: String, data: Array[Byte], gzipped: Boolean): String = {
+    val finalData =
+      if (gzipped) {
+        val dataOutputStream = new ByteArrayOutputStream
+        val gzipOutputStream = new GZIPOutputStream(dataOutputStream)
+
+        gzipOutputStream.write(data, 0, data.length)
+        gzipOutputStream.close
+
+        dataOutputStream.toByteArray
+      } else {
+        data
+      }
+
     val metadata = new ObjectMetadata
     metadata.setContentType(mime)
-    metadata.setContentLength(data.length)
+    metadata.setContentLength(finalData.length)
+    if (gzipped) {
+      metadata.setContentEncoding("gzip")
+    }
 
-    val dataStream = new ByteArrayInputStream(data)
+    val dataStream = new ByteArrayInputStream(finalData)
     val request =
       new PutObjectRequest(bucket, fileName, dataStream, metadata)
         .withAccessControlList(bucketAcl)

--- a/src/main/scala/com/openstudy/sbt/S3Helpers.scala
+++ b/src/main/scala/com/openstudy/sbt/S3Helpers.scala
@@ -37,17 +37,21 @@ class S3Handler(bucket: String, val accessKey: Option[String], val secretKey: Op
     acl
   }
 
+  private def gzipData(data: Array[Byte]): Array[Byte] = {
+    val dataOutputStream = new ByteArrayOutputStream
+    val gzipOutputStream = new GZIPOutputStream(dataOutputStream)
+
+    gzipOutputStream.write(data, 0, data.length)
+    gzipOutputStream.close
+
+    dataOutputStream.toByteArray
+  }
+
   // Returns the MD5 checksum of the file.
   def saveFile(mime: String, fileName: String, data: Array[Byte], gzipped: Boolean): String = {
     val finalData =
       if (gzipped) {
-        val dataOutputStream = new ByteArrayOutputStream
-        val gzipOutputStream = new GZIPOutputStream(dataOutputStream)
-
-        gzipOutputStream.write(data, 0, data.length)
-        gzipOutputStream.close
-
-        dataOutputStream.toByteArray
+        gzipData(data)
       } else {
         data
       }

--- a/src/main/scala/com/openstudy/sbt/S3Helpers.scala
+++ b/src/main/scala/com/openstudy/sbt/S3Helpers.scala
@@ -37,7 +37,7 @@ class S3Handler(bucket: String, val accessKey: Option[String], val secretKey: Op
   }
 
   // Returns the MD5 checksum of the file.
-  def saveFile(mime: String, fileName: String, data: Array[Byte]): String = {
+  def saveFile(mime: String, fileName: String, data: Array[Byte], gzipped: Boolean): String = {
     val metadata = new ObjectMetadata
     metadata.setContentType(mime)
     metadata.setContentLength(data.length)

--- a/src/main/scala/com/openstudy/sbt/ScriptDeployment.scala
+++ b/src/main/scala/com/openstudy/sbt/ScriptDeployment.scala
@@ -11,7 +11,8 @@ trait ScriptDeployment extends Deployment {
 
   def doScriptDeploy(
       streams: TaskStreams,
-      checksumInFilename: Boolean, bundleChecksums: Map[String,String],
+      checksumInFilename: Boolean, gzipFiles: Boolean,
+      bundleChecksums: Map[String,String],
       scriptBundleVersions: File, compressedTarget: File,
       access: Option[String], secret: Option[String], defaultBucket: Option[String]) = {
     val bundles = (compressedTarget / "javascripts" ** "*.js").get
@@ -20,7 +21,7 @@ trait ScriptDeployment extends Deployment {
       withBucketMapping(bundles, defaultBucket, customBucketMap) { (bucketName, files) =>
         doDeploy(
           streams,
-          checksumInFilename,
+          checksumInFilename, gzipFiles,
           bundleChecksums,
           scriptBundleVersions, compressedTarget,
           files, "text/javascript",


### PR DESCRIPTION
Resources are gzipped in-memory before transmission to S3, where
they are properly marked with Content-Encoding: gzip.

This also fixes the snapshot version to 0.5.0-SNAPSHOT.